### PR TITLE
Add monish Bash server monitoring tool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
-This is free and unencumbered software released into the public domain.
+MIT License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Copyright (c) 2024 monish
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-For more information, please refer to <https://unlicense.org>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# monish
+
+Lightweight Bash server monitoring dashboard.
+
+## Features
+- Single-screen terminal dashboard
+- CPU load, RAM%, disk%, uptime, ping
+- Parallel SSH checks with minimal dependencies
+- Color thresholds
+- JSON output for automation
+
+## Requirements
+- Bash
+- OpenSSH client
+- Common GNU utilities: awk, sed, grep, df, free, ping, tput
+
+## Quick start
+```bash
+git clone <repo>
+cd monish
+cp monish.conf.example monish.conf
+# edit monish.conf
+./monish.sh -c monish.conf
+```
+
+One-shot and JSON:
+```bash
+./monish.sh --once
+./monish.sh --json --once > out.json
+```
+
+## Config reference
+All keys and defaults are shown in `monish.conf.example`. Define servers with sections:
+```
+[server "name"]
+host=1.2.3.4
+user=ubuntu
+```
+
+## Color thresholds
+| Metric | Green | Yellow | Red |
+|--------|-------|--------|-----|
+| Load1  | <1    | 1-2    | >2  |
+| RAM%   | <70   | 70-85  | >85 |
+| Disk%  | <70   | 70-85  | >85 |
+| Ping ms| <50   | 50-150 | >150 |
+
+## Security
+Use key-based auth or SSH agent. Password auth requires `sshpass` and is not recommended.
+
+## Troubleshooting
+- Ensure SSH connectivity and permissions.
+- Timeouts or ERR status indicate unreachable hosts.
+
+## License
+MIT

--- a/modules/collectors.sh
+++ b/modules/collectors.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# assumes config arrays and util functions loaded
+
+collect_local() {
+  local load mem disk up
+  load=$(awk '{print $1}' /proc/loadavg)
+  mem=$(awk '/MemTotal/{t=$2}/MemAvailable/{a=$2} END{printf "%.0f",(1-a/t)*100}' /proc/meminfo)
+  disk=$(df -P / | awk 'NR==2{print $5}' | tr -d '%')
+  if command_exists uptime && uptime -p >/dev/null 2>&1; then
+    up=$(uptime -p | sed 's/^up //')
+  else
+    up=$(awk '{print int($1)}' /proc/uptime)
+    up=$(humanize_seconds "$up")
+  fi
+  printf '%s\t%s\t%s\t%s\n' "$load" "$mem" "$disk" "$up"
+}
+
+collect_remote() {
+  local host=$1 user=$2 port=$3 auth=$4 key=$5 opts=$6
+  local cmd='load=$(awk '\''{print $1}'\'' /proc/loadavg);\
+mem=$(awk '\''/MemTotal/{t=$2}/MemAvailable/{a=$2} END{printf "%.0f",(1-a/t)*100}'\'' /proc/meminfo);\
+disk=$(df -P / | awk '\''NR==2{print $5}'\'' | tr -d "%");\
+up=$(awk '\''{print int($1)}'\'' /proc/uptime);\
+printf "%s %s %s %s\n" "$load" "$mem" "$disk" "$up"'
+  if out=$(run_ssh "$host" "$user" "$port" "$auth" "$key" "$opts" "$cmd" 2>/dev/null); then
+    read -r load mem disk up <<<"$out"
+    up=$(humanize_seconds "$up")
+    printf '%s\t%s\t%s\t%s\n' "$load" "$mem" "$disk" "$up"
+    return 0
+  fi
+  return 1
+}
+
+collect_one_server() {
+  local i=$1 name host user port auth key opts
+  name=${SERVER_NAME[i]}
+  host=${SERVER_HOST[i]}
+  user=${SERVER_USER[i]}
+  port=${SERVER_PORT[i]}
+  auth=${SERVER_AUTH[i]}
+  key=${SERVER_KEY_PATH[i]}
+  opts=${SERVER_SSH_OPTIONS[i]}
+
+  local ping_ms="" status="OK" load="" mem="" disk="" up=""
+  if out=$(ping -c "$PING_COUNT" -W "$PING_TIMEOUT" "$host" 2>/dev/null); then
+    ping_ms=$(echo "$out" | awk -F'time=' '/time=/{print $2}' | cut -d' ' -f1)
+  fi
+  if [[ $host == "localhost" || $host == "127.0.0.1" ]]; then
+    if out=$(collect_local); then
+      read -r load mem disk up <<<"$out"
+    else
+      status="ERR"
+    fi
+  else
+    if out=$(collect_remote "$host" "$user" "$port" "$auth" "$key" "$opts"); then
+      read -r load mem disk up <<<"$out"
+    else
+      status="ERR"
+    fi
+  fi
+  [[ -z $load || -z $mem || -z $disk || -z $up ]] && status="ERR"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$name" "$host" "$ping_ms" "$load" "$mem" "$disk" "$up" "$status"
+}
+
+collect_all() {
+  local tmpdir=$(mktemp -d)
+  for i in $(seq 0 $((SERVER_COUNT-1))); do
+    limit_jobs "$CONCURRENCY"
+    collect_one_server "$i" >"$tmpdir/$i" &
+  done
+  wait
+  sort -n "$tmpdir"/* 2>/dev/null | cat
+  rm -rf "$tmpdir"
+}

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -Ag DEFAULTS=()
+declare -ag SERVER_NAME SERVER_HOST SERVER_USER SERVER_PORT SERVER_AUTH SERVER_KEY_PATH SERVER_SSH_OPTIONS
+
+parse_config() {
+  local file="$1"
+  local section="" name="" idx=-1 line key value
+  while IFS= read -r line || [[ -n $line ]]; do
+    line=${line%%#*}; line=${line%%;*}
+    line=$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    [[ -z $line ]] && continue
+    if [[ $line == "[defaults]" ]]; then
+      section=defaults
+      continue
+    elif [[ $line == \[server* ]]; then
+      name=${line#"[server \""}
+      name=${name%"\"]"}
+      section=server
+      ((idx++))
+      SERVER_NAME[idx]="$name"
+      continue
+    fi
+    if [[ $line == *=* ]]; then
+      key=$(echo "${line%%=*}" | tr -d ' ')
+      value=$(echo "${line#*=}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^"//' -e 's/"$//')
+      if [[ $section == defaults ]]; then
+        DEFAULTS[$key]="$value"
+      elif [[ $section == server ]]; then
+        case $key in
+          host) SERVER_HOST[idx]="$value";;
+          user) SERVER_USER[idx]="$value";;
+          port) SERVER_PORT[idx]="$value";;
+          auth) SERVER_AUTH[idx]="$value";;
+          key_path) SERVER_KEY_PATH[idx]="$value";;
+          ssh_options) SERVER_SSH_OPTIONS[idx]="$value";;
+        esac
+      fi
+    fi
+  done < "$file"
+
+  local total=$((idx+1))
+  for i in $(seq 0 $((total-1))); do
+    : "${SERVER_HOST[i]:?Missing host for ${SERVER_NAME[i]}}"
+    SERVER_USER[i]=${SERVER_USER[i]:-${DEFAULTS[user]:-root}}
+    SERVER_PORT[i]=${SERVER_PORT[i]:-${DEFAULTS[port]:-22}}
+    SERVER_AUTH[i]=${SERVER_AUTH[i]:-${DEFAULTS[auth]:-agent}}
+    SERVER_KEY_PATH[i]=${SERVER_KEY_PATH[i]:-${DEFAULTS[key_path]:-$HOME/.ssh/id_rsa}}
+    SERVER_SSH_OPTIONS[i]=${SERVER_SSH_OPTIONS[i]:-${DEFAULTS[ssh_options]:-"-o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no"}}
+  done
+  SERVER_COUNT=$total
+  REFRESH_SEC=${DEFAULTS[refresh_sec]:-3}
+  CONCURRENCY=${DEFAULTS[concurrency]:-10}
+  PING_COUNT=${DEFAULTS[ping_count]:-1}
+  PING_TIMEOUT=${DEFAULTS[ping_timeout]:-1}
+}

--- a/modules/render.sh
+++ b/modules/render.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# color helpers
+init_colors() {
+  RESET=$(tput sgr0)
+  RED=$(tput setaf 1)
+  GREEN=$(tput setaf 2)
+  YELLOW=$(tput setaf 3)
+  GREY=$(tput setaf 8)
+  BOLD=$(tput bold)
+}
+
+color_load() { local v=$1; awk -v v="$v" -v g="$GREEN" -v y="$YELLOW" -v r="$RED" 'BEGIN{if(v<1)print g; else if(v<2)print y; else print r}'; }
+color_percent() { local v=$1; awk -v v="$v" -v g="$GREEN" -v y="$YELLOW" -v r="$RED" 'BEGIN{if(v<70)print g; else if(v<85)print y; else print r}'; }
+color_ping() { local v=$1; if [[ -z $v ]]; then echo "$GREY"; else awk -v v="$v" -v g="$GREEN" -v y="$YELLOW" -v r="$RED" 'BEGIN{if(v<50)print g; else if(v<150)print y; else print r}'; fi }
+
+render_table() {
+  init_colors
+  local ts
+  ts=$(date '+%Y-%m-%d %H:%M:%S')
+  tput clear
+  printf "%smonish%s - %s refresh %ss (q to quit)\n" "$BOLD" "$RESET" "$ts" "$REFRESH_SEC"
+  printf "%s%-12s %-20s %-8s %-8s %-6s %-6s %-12s %-6s%s\n" "$BOLD" "NAME" "HOST" "PING(ms)" "LOAD1" "RAM%" "DISK%" "UPTIME" "STATUS" "$RESET"
+  while IFS=$'\t' read -r name host ping load mem disk up status; do
+    local pl cl cm cd cs
+    pl=$(color_ping "$ping"); cl=$(color_load "$load"); cm=$(color_percent "$mem"); cd=$(color_percent "$disk")
+    cs=$GREEN
+    [[ $status != OK ]] && cs=$RED
+    printf "%-12s %-20s %s%-8s%s %s%-8s%s %s%-6s%s %s%-6s%s %-12s %s%-6s%s\n" \
+      "$name" "${host:0:20}" "$pl" "${ping:-"---"}" "$RESET" "$cl" "$load" "$RESET" "$cm" "$mem" "$RESET" "$cd" "$disk" "$RESET" "$up" "$cs" "$status" "$RESET"
+  done <<< "$1"
+}
+
+json_num() { [[ -z $1 ]] && echo null || echo "$1"; }
+
+render_json() {
+  local lines="$1" first=1 ts
+  ts=$(date -Iseconds)
+  printf '['
+  while IFS=$'\t' read -r name host ping load mem disk up status; do
+    [[ $first -eq 0 ]] && printf ','
+    printf '\n  {"name":"%s","host":"%s","ping_ms":%s,"load1":%s,"ram_pct":%s,"disk_pct":%s,"uptime":"%s","status":"%s","ts":"%s"}' \
+      "$name" "$host" "$(json_num "$ping")" "$(json_num "$load")" "$(json_num "$mem")" "$(json_num "$disk")" "$up" "$status" "$ts"
+    first=0
+  done <<< "$lines"
+  printf '\n]\n'
+}

--- a/modules/util.sh
+++ b/modules/util.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+humanize_seconds() {
+  local s=$1 d h m
+  d=$((s/86400)); s=$((s%86400))
+  h=$((s/3600)); s=$((s%3600))
+  m=$((s/60))
+  local out=""
+  [[ $d -gt 0 ]] && out+="${d}d "
+  [[ $h -gt 0 ]] && out+="${h}h "
+  out+="${m}m"
+  echo "$out"
+}
+
+run_ssh() {
+  local host=$1 user=$2 port=$3 auth=$4 key=$5 opts=$6 cmd=$7
+  local ssh_cmd=(ssh -p "$port")
+  IFS=' ' read -r -a extra <<<"$opts"
+  ssh_cmd+=("${extra[@]}")
+  if [[ $auth == key ]]; then
+    ssh_cmd+=(-i "$key")
+  elif [[ $auth == password ]]; then
+    command_exists sshpass || return 1
+    ssh_cmd=(sshpass -p "${SSH_PASSWORD:-}" "${ssh_cmd[@]}")
+  fi
+  ssh_cmd+=("$user@$host" "$cmd")
+  "${ssh_cmd[@]}"
+}
+
+limit_jobs() {
+  local max=$1
+  while [[ $(jobs -p | wc -l) -ge $max ]]; do
+    wait -n 2>/dev/null || true
+  done
+}

--- a/monish.conf.example
+++ b/monish.conf.example
@@ -1,0 +1,13 @@
+[defaults]
+port=22
+user=root
+auth=agent
+key_path=~/.ssh/id_rsa
+ssh_options=-o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no
+refresh_sec=3
+concurrency=10
+ping_count=1
+ping_timeout=1
+
+[server "local"]
+host=localhost

--- a/monish.sh
+++ b/monish.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Monish main entrypoint
+
+VERSION="0.1.0"
+
+print_help() {
+  cat <<'HLP'
+monish - lightweight server monitor
+Usage: ./monish.sh [options]
+  -c, --config FILE   config file path (default: ./monish.conf or ./monish.conf.example)
+      --once          run one iteration and exit
+      --json          output JSON (implies --once)
+      --version       show version
+      --help          this help
+HLP
+}
+
+CONFIG=""; ONCE=false; JSON=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -c|--config)
+      CONFIG="$2"; shift 2;;
+    --once)
+      ONCE=true; shift;;
+    --json)
+      JSON=true; ONCE=true; shift;;
+    --version)
+      echo "$VERSION"; exit 0;;
+    --help)
+      print_help; exit 0;;
+    *)
+      echo "Unknown option: $1" >&2; exit 1;;
+  esac
+done
+
+if [[ -z "$CONFIG" ]]; then
+  if [[ -f ./monish.conf ]]; then
+    CONFIG=./monish.conf
+  else
+    CONFIG=./monish.conf.example
+  fi
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=modules/util.sh
+source "$SCRIPT_DIR/modules/util.sh"
+# shellcheck source=modules/config.sh
+source "$SCRIPT_DIR/modules/config.sh"
+# shellcheck source=modules/collectors.sh
+source "$SCRIPT_DIR/modules/collectors.sh"
+# shellcheck source=modules/render.sh
+source "$SCRIPT_DIR/modules/render.sh"
+
+parse_config "$CONFIG"
+
+cleanup() {
+  stty sane 2>/dev/null || true
+  $JSON || tput cnorm 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+main_loop() {
+  $JSON || tput civis 2>/dev/null || true
+  while true; do
+    local data
+    data=$(collect_all)
+    if $JSON; then
+      render_json "$data"
+      break
+    else
+      render_table "$data"
+    fi
+    $ONCE && break
+    local key=""
+    read -t "$REFRESH_SEC" -n 1 key && [[ $key == "q" ]] && break
+  done
+}
+
+main_loop

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+out=$(./monish.sh --json --once -c monish.conf.example)
+echo "$out" | grep -q '^\['
+if command -v jq >/dev/null 2>&1; then
+  echo "$out" | jq -e '. | length >= 1' >/dev/null
+else
+  echo "$out" | grep -q '"status"'
+fi
+echo "smoke test passed"


### PR DESCRIPTION
## Summary
- Implement lightweight `monish` Bash dashboard for monitoring servers via SSH with metrics like load, RAM, disk, uptime and ping
- Add config parser, collectors, rendering with color thresholds, and JSON output
- Provide example config, README, MIT license, and smoke test

## Testing
- `tests/smoke.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bdcaad6a74832189f563d27fa3a104