### PR TITLE
Handle comments outside quotes in config parser

### DIFF
--- a/modules/config.sh
+++ b/modules/config.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Parse configuration file setting variables in the calling shell.
+# Lines beginning with # or ; are ignored as comments. # or ; inside
+# quotes are preserved.
+
+parse_config() {
+    local file="$1"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Use awk to strip comments only when outside quotes
+        line=$(printf '%s\n' "$line" | awk '{
+            inquote=0; out="";
+            for(i=1;i<=length($0);i++){
+                c=substr($0,i,1);
+                if(c=="\"") inquote=1-inquote;
+                if((c=="#" || c==";") && inquote==0) break;
+                out=out c;
+            }
+            sub(/[ \t]+$/, "", out);
+            print out;
+        }')
+
+        # Trim leading whitespace
+        line="${line#"${line%%[![:space:]]*}"}"
+        [[ -z "$line" ]] && continue
+        [[ "$line" == \#* || "$line" == \;* ]] && continue
+
+        if [[ "$line" == *"="* ]]; then
+            local key="${line%%=*}"
+            local value="${line#*=}"
+            key="${key%"${key##*[![:space:]]}"}"
+            value="${value#"${value%%[![:space:]]*}"}"
+            eval "$key=$value"
+        fi
+    done < "$file"
+}
+

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/../modules/config.sh"
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; exit 1; }
+
+test_hash_in_quotes() {
+    local cfg
+    cfg=$(mktemp)
+    cat <<'CFG' > "$cfg"
+ssh_options="ProxyCommand ssh -W %h:%p jump#host"
+CFG
+    parse_config "$cfg"
+    [[ "$ssh_options" == 'ProxyCommand ssh -W %h:%p jump#host' ]]
+}
+
+test_hash_outside_quotes() {
+    local cfg
+    cfg=$(mktemp)
+    cat <<'CFG' > "$cfg"
+user=me # comment
+CFG
+    parse_config "$cfg"
+    [[ "$user" == 'me' ]]
+}
+
+test_semicolon_in_quotes() {
+    local cfg
+    cfg=$(mktemp)
+    cat <<'CFG' > "$cfg"
+ssh_options="ProxyCommand ssh -W %h:%p jump;host"
+CFG
+    parse_config "$cfg"
+    [[ "$ssh_options" == 'ProxyCommand ssh -W %h:%p jump;host' ]]
+}
+
+run_tests() {
+    test_hash_in_quotes && pass "hash_in_quotes" || fail "hash_in_quotes"
+    unset ssh_options user
+    test_hash_outside_quotes && pass "hash_outside_quotes" || fail "hash_outside_quotes"
+    unset ssh_options user
+    test_semicolon_in_quotes && pass "semicolon_in_quotes" || fail "semicolon_in_quotes"
+}
+
+run_tests
+


### PR DESCRIPTION
## Summary
- parse config files while preserving `#` and `;` characters inside quoted values
- add tests covering quoted and unquoted comment characters

## Testing
- `bash tests/test_config.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bdcf70e61c8321927ec84d2765c615