### PR TITLE
Ensure collectors output respects server order

### DIFF
--- a/modules/collectors.sh
+++ b/modules/collectors.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Collector utilities for assembling server output
+#
+# This script writes each server's output to numbered files in a temporary
+# directory. When collecting the results, the files are read back in
+# numeric filename order so that the server output order matches the
+# order provided in the SERVER_NAME variable.
+
+collect_servers() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local i=0
+    for server in $SERVER_NAME; do
+        printf '%s\n' "$server" > "$tmpdir/$i"
+        i=$((i + 1))
+    done
+
+    # Concatenate each file in numeric order of the filename to preserve
+    # the order of SERVER_NAME. Using a numeric glob avoids relying on
+    # the contents of the files for ordering.
+    for f in "$tmpdir"/[0-9]*; do
+        cat "$f"
+    done
+
+    rm -rf "$tmpdir"
+}
+

--- a/tests/test_collectors.sh
+++ b/tests/test_collectors.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/modules/collectors.sh"
+
+# Regression test: the output of collect_servers must match the order of
+# SERVER_NAME. This previously failed because the implementation sorted by
+# file contents rather than numeric filename.
+
+SERVER_NAME="100 5 20"
+result="$(collect_servers)"
+# Command substitution strips the trailing newline, so the expected string
+# deliberately omits it as well.
+expected=$'100\n5\n20'
+if [ "$result" != "$expected" ]; then
+    echo "Expected:\n$expected" >&2
+    echo "Got:\n$result" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- read temporary files in numeric filename order instead of sorting by content
- add regression test verifying server output order matches SERVER_NAME order

## Testing
- `bash tests/test_collectors.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bdcf72116c8321aa6e3486234125cf