### PR TITLE
Add early Bash check in monish.sh

### DIFF
--- a/monish.sh
+++ b/monish.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Ensure the script is executed with Bash. If invoked with a different shell
+# (e.g. `sh monish.sh`), emit a clear error before using Bash-specific options
+# like `pipefail`.
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "Error: monish.sh requires bash. Run it with 'bash monish.sh' or make it executable." >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 # Monish main entrypoint


### PR DESCRIPTION
## Summary
- fail fast with a clear error if `monish.sh` is invoked by a non-Bash shell

## Testing
- `bash tests/smoke.sh`
- `bash tests/test_collectors.sh`
- `bash tests/test_config.sh`
- `sh monish.sh --version` *(fails with helpful message)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd7a937088321b76d3a0716df4673