### PR TITLE
Add early Bash check in monish.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts use LF line endings
+*.sh text eol=lf

--- a/modules/collectors.sh
+++ b/modules/collectors.sh
@@ -24,3 +24,11 @@ collect_servers() {
 
     rm -rf "$tmpdir"
 }
+
+# collect_all: gather data from all configured collectors. For now this
+# simply returns the server names in the order provided by SERVER_NAME.
+# This placeholder prevents the main script from failing when invoking
+# collect_all and can be extended with additional collectors later.
+collect_all() {
+    collect_servers
+}

--- a/monish.sh
+++ b/monish.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+
+# Ensure the script is executed with Bash. If invoked with a different shell
+# (e.g. `sh monish.sh`), emit a clear error before using Bash-specific options
+# like `pipefail`.
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "Error: monish.sh requires bash. Run it with 'bash monish.sh' or make it executable." >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 # Monish main entrypoint

--- a/tests/test_collectors.sh
+++ b/tests/test_collectors.sh
@@ -18,3 +18,13 @@ if [ "$result" != "$expected" ]; then
     echo "Got:\n$result" >&2
     exit 1
 fi
+
+# collect_all should currently behave identically to collect_servers
+result_all="$(collect_all)"
+if [ "$result_all" != "$expected" ]; then
+    echo "collect_all mismatch" >&2
+    echo "Expected:\n$expected" >&2
+    echo "Got:\n$result_all" >&2
+    exit 1
+fi
+


### PR DESCRIPTION
## Summary
- fail fast with a clear error if `monish.sh` is invoked by a non-Bash shell
- ensure shell scripts use LF line endings to avoid stray `$'\r'` errors
- provide a placeholder `collect_all` collector so the main script runs without missing function errors

## Testing
- `bash tests/smoke.sh`
- `bash tests/test_collectors.sh`
- `bash tests/test_config.sh`
- `sh monish.sh --version`
- `bash monish.sh --version`


------
https://chatgpt.com/codex/tasks/task_e_68bdd7a937088321b76d3a0716df4673