### PR TITLE
Validate SERVER_NAME before collecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ host=1.2.3.4
 user=ubuntu
 ```
 
+## Environment variables
+The collectors module reads server names from the `SERVER_NAME` environment variable. It must contain a space-separated list of servers before running `collect_servers` or `collect_all` directly:
+```bash
+export SERVER_NAME="web1 db1"
+```
+
 ## Color thresholds
 | Metric | Green | Yellow | Red |
 |--------|-------|--------|-----|

--- a/modules/collectors.sh
+++ b/modules/collectors.sh
@@ -7,6 +7,7 @@
 # order provided in the SERVER_NAME variable.
 
 collect_servers() {
+    [[ -n ${SERVER_NAME:-} ]] || { echo "SERVER_NAME not set" >&2; return 1; }
     local tmpdir
     tmpdir=$(mktemp -d)
     local i=0

--- a/tests/test_collectors.sh
+++ b/tests/test_collectors.sh
@@ -28,3 +28,14 @@ if [ "$result_all" != "$expected" ]; then
     exit 1
 fi
 
+# collect_servers should fail when SERVER_NAME is unset
+unset SERVER_NAME
+if output=$(collect_servers 2>&1); then
+    echo "expected collect_servers to fail without SERVER_NAME" >&2
+    exit 1
+fi
+if [[ "$output" != "SERVER_NAME not set" ]]; then
+    echo "unexpected error: $output" >&2
+    exit 1
+fi
+


### PR DESCRIPTION
## Summary
- ensure collect_servers aborts when SERVER_NAME is missing
- document SERVER_NAME requirement for collectors
- test collectors handle missing SERVER_NAME

## Testing
- `bash tests/test_collectors.sh`
- `bash tests/test_config.sh`
- `bash tests/smoke.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bde44daa188321ab765f61ba1c9847