### PR TITLE
Implement basic renderers for monish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+monish.conf

--- a/modules/render.sh
+++ b/modules/render.sh
@@ -18,3 +18,36 @@ render_json_line() {
   uptime="$(escape_json "$3")"
   printf '{"name":"%s","host":"%s","uptime":"%s"}\n' "$name" "$host" "$uptime"
 }
+
+# render_json data
+# Renders the collected data as a JSON array. Each line of input is treated
+# as a server name. Host and uptime fields are left empty for now.
+render_json() {
+  local data="$1"
+  local first=true
+  printf '['
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" ]] && continue
+    if $first; then
+      first=false
+    else
+      printf ','
+    fi
+    local json_line
+    json_line=$(render_json_line "$line" "" "" | tr -d '\n')
+    printf '\n  %s' "$json_line"
+  done <<< "$data"
+  printf '\n]\n'
+}
+
+# render_table data
+# Displays the collected data in a simple table. Each line of input is
+# rendered on its own line under a "NAME" header.
+render_table() {
+  local data="$1"
+  tput clear 2>/dev/null || true
+  printf '%-20s\n' "NAME"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    printf '%-20s\n' "$line"
+  done <<< "$data"
+}


### PR DESCRIPTION
## Summary
- Add `render_json` to convert collected data into a JSON array using existing escaping utilities
- Add `render_table` to print simple server table output
- Ignore `monish.conf` to keep local config out of version control

## Testing
- `./tests/test_config.sh`
- `./tests/test_collectors.sh`
- `./tests/smoke.sh`
- `SERVER_NAME="local" REFRESH_SEC=1 ./monish.sh --json`


------
https://chatgpt.com/codex/tasks/task_e_68bde7e7c0cc8321bb8f477e1ed2c0f3