### PR TITLE
test: parse config for collectors

### DIFF
--- a/tests/test_collectors.sh
+++ b/tests/test_collectors.sh
@@ -19,6 +19,10 @@ host=localhost
 host=localhost
 CFG
 parse_config "$cfg"
+if env | grep -q '^SERVER_NAME='; then
+    echo "SERVER_NAME should not be exported" >&2
+    exit 1
+fi
 result="$(collect_servers)"
 # Command substitution strips the trailing newline, so the expected string
 # deliberately omits it as well.


### PR DESCRIPTION
## Summary
- ensure collector tests parse config to set `SERVER_NAME`
- verify collectors work without exporting `SERVER_NAME`

## Testing
- `tests/test_collectors.sh`
- `tests/test_config.sh`
- `tests/smoke.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c2ec0e49848321a86967d1f5ae3937