### PR TITLE
Add disk usage collector and rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ One-shot and JSON:
 ./monish.sh --json --once > out.json
 ```
 
+## Disk usage collection
+monish gathers disk usage by executing `df -h /` on each server over SSH and
+parsing the used percentage. Ensure the `df` utility is available on the remote
+host; the root filesystem `/` is checked by default.
+
 ## Config reference
 All keys and defaults are shown in `monish.conf.example`. Define servers with sections:
 ```

--- a/monish.conf.example
+++ b/monish.conf.example
@@ -9,6 +9,7 @@ refresh_sec=3
 concurrency=10
 ping_count=1
 ping_timeout=1
+# Disk usage metrics run `df -h /` on the remote host.
 
 [server "local"]
 host=localhost

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT_DIR/modules/render.sh"
 
 # Use a server name containing quotes to ensure escaping works
-json_output=$(render_json_line 'server "alpha"' 'host1' '1 day')
+json_output=$(render_json_line 'server "alpha"' 'host1' '1 day' '50%')
 
 echo "$json_output"
 

--- a/tests/test_collectors.sh
+++ b/tests/test_collectors.sh
@@ -58,7 +58,15 @@ parse_config "$cfg"
 
 run_ssh() {
     local host=$1 user=$2 port=$3 auth=$4 key=$5 opts=$6 cmd=$7
-    echo "$user@$host:$cmd"
+    if [[ $cmd == "df -h / --output=pcent | tail -n 1" ]]; then
+        if [[ $host == host1 ]]; then
+            echo "10%"
+        else
+            echo "20%"
+        fi
+    else
+        echo "$user@$host:$cmd"
+    fi
 }
 
 expected_remote=$'alpha\tuser1@host1:uptime\nbeta\tuser2@host2:uptime'
@@ -70,10 +78,20 @@ if [ "$result_remote" != "$expected_remote" ]; then
     exit 1
 fi
 
+expected_disk=$'alpha\t10%\nbeta\t20%'
+result_disk="$(collect_disk_usage)"
+if [ "$result_disk" != "$expected_disk" ]; then
+    echo "collect_disk_usage mismatch" >&2
+    echo "Expected:\n$expected_disk" >&2
+    echo "Got:\n$result_disk" >&2
+    exit 1
+fi
+
+expected_all=$'alpha\tuser1@host1:uptime\t10%\nbeta\tuser2@host2:uptime\t20%'
 result_all="$(collect_all uptime)"
-if [ "$result_all" != "$expected_remote" ]; then
+if [ "$result_all" != "$expected_all" ]; then
     echo "collect_all mismatch" >&2
-    echo "Expected:\n$expected_remote" >&2
+    echo "Expected:\n$expected_all" >&2
     echo "Got:\n$result_all" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- collect disk usage for each server via SSH and include in aggregate output
- render disk usage in JSON and table formats
- document disk usage collection and add tests

## Testing
- `bash tests/test_collectors.sh`
- `bash tests/test_config.sh`
- `bash tests/smoke.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c31c8d407483218b6b8be2b0ea636d