### PR TITLE
Trim disk usage output

### DIFF
--- a/modules/collectors.sh
+++ b/modules/collectors.sh
@@ -57,7 +57,7 @@ collect_disk_usage() {
         local key=${KEY_PATH[$server]:-}
         local opts=${SSH_OPTIONS[$server]:-}
         local password=${PASSWORD[$server]:-}
-        local cmd="df -h / --output=pcent | tail -n 1"
+        local cmd="df -h / --output=pcent | tail -n 1 | awk '{\$1=\$1};1'"
         local usage
         SSH_PASSWORD="$password" usage=$(run_ssh "$host" "$user" "$port" "$auth" "$key" "$opts" "$cmd")
         printf '%s\t%s\n' "$server" "$usage"

--- a/tests/test_collectors.sh
+++ b/tests/test_collectors.sh
@@ -59,7 +59,7 @@ parse_config "$cfg"
 
 run_ssh() {
     local host=$1 user=$2 port=$3 auth=$4 key=$5 opts=$6 cmd=$7
-    if [[ $cmd == "df -h / --output=pcent | tail -n 1" ]]; then
+    if [[ $cmd == "df -h / --output=pcent | tail -n 1 | awk '{\$1=\$1};1'" ]]; then
         if [[ $host == host1 ]]; then
             echo "10%"
         else


### PR DESCRIPTION
## Summary
- strip whitespace from `df` percentage output in `collect_disk_usage`
- update tests for new `df` command

## Testing
- `tests/test_collectors.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c3225076bc83218e1bfcd6b0e4a75c