### PR TITLE
Colorize disk and RAM usage output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lightweight Bash server monitoring dashboard.
 - Single-screen terminal dashboard
 - CPU load, RAM%, disk%, uptime, ping
 - Parallel SSH checks with minimal dependencies
-- Color thresholds
+- Color thresholds for load, RAM%, disk%, and ping
 - JSON output for automation
 
 ## Requirements
@@ -68,6 +68,9 @@ The refresh interval is configured via `refresh_sec` (default 3 seconds). `monis
 | RAM%   | <70   | 70-85  | >85 |
 | Disk%  | <70   | 70-85  | >85 |
 | Ping ms| <50   | 50-150 | >150 |
+
+Disk% and RAM% values displayed in the table are wrapped in green/yellow/red
+colors based on these thresholds.
 
 ## Security
 Use key-based auth or SSH agent. Password auth requires `sshpass` and is not recommended.

--- a/tests/test_collectors.sh
+++ b/tests/test_collectors.sh
@@ -127,10 +127,12 @@ fi
 
 tput() { :; }
 result_table="$(render_table "$data")"
+# Strip ANSI color codes for comparison
+stripped_table="$(printf '%s' "$result_table" | sed -E 's/\x1b\[[0-9;]*m//g')"
 expected_table=$(printf '%-20s %-20s %-10s %-10s\n' "NAME" "UPTIME" "DISK%" "RAM%"; \
                  printf '%-20s %-20s %-10s %-10s\n' "alpha" "user1@host1:uptime" "10%" "30%"; \
                  printf '%-20s %-20s %-10s %-10s' "beta" "user2@host2:uptime" "20%" "40%")
-if [ "$result_table" != "$expected_table" ]; then
+if [ "$stripped_table" != "$expected_table" ]; then
     echo "render_table mismatch" >&2
     echo "Expected:\n$expected_table" >&2
     echo "Got:\n$result_table" >&2


### PR DESCRIPTION
## Summary
- add color helper functions using ANSI escape codes
- colorize disk and RAM usage in the table based on thresholds
- document color behavior and adapt tests to strip ANSI codes

## Testing
- `./tests/smoke.sh`
- `./tests/test_collectors.sh`
- `./tests/test_config.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c3239fafc88321b501e4c3244887b8