### PR TITLE
Remove BatchMode option from example config

### DIFF
--- a/monish.conf.example
+++ b/monish.conf.example
@@ -4,7 +4,7 @@ port=22
 user=root
 auth=agent
 key_path=~/.ssh/id_rsa
-ssh_options=-o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no
+ssh_options=-o ConnectTimeout=5 -o StrictHostKeyChecking=no
 refresh_sec=3
 concurrency=10
 ping_count=1


### PR DESCRIPTION
## Summary
- update the example SSH options to remove BatchMode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdacd095408321827a040ea3c74b86